### PR TITLE
Fix: Clean up glossary strings from Excel imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.example</groupId>
   <artifactId>translator</artifactId>
-  <version>1.1.7</version>
+  <version>1.1.8</version>
   <dependencies>
     <dependency>
       <groupId>com.deepl.api</groupId>

--- a/src/main/java/org/example/GlossaryManager.java
+++ b/src/main/java/org/example/GlossaryManager.java
@@ -106,13 +106,13 @@ public class GlossaryManager {
                     if (row.getCell(i) != null) {
                         String cellValue = "";
                         if (row.getCell(i).getCellType() == CellType.STRING) {
-                            cellValue = row.getCell(i).getStringCellValue().trim();
+                            cellValue = row.getCell(i).getStringCellValue();
                         } else if (row.getCell(i).getCellType() == CellType.NUMERIC) {
-                            cellValue = String.valueOf(row.getCell(i).getNumericCellValue()).trim();
+                            cellValue = String.valueOf(row.getCell(i).getNumericCellValue());
                         }
 
-                        cellValue = cellValue.replace("\"", "");
-                        cellValues[i] = removeTrailingWhitespaces(cellValue);
+                        cellValue = cellValue.replace('\u00A0', ' ').replace("\"", "").trim();
+                        cellValues[i] = cellValue;
                     }
                 }
 
@@ -159,17 +159,6 @@ public class GlossaryManager {
             throw new RuntimeException(e);
         }
         return map;
-    }
-
-    private String removeTrailingWhitespaces(String input) {
-        if (input == null) {
-            return null;
-        }
-        int end = input.length() - 1;
-        while (end >= 0 && (Character.isWhitespace(input.charAt(end)) || input.charAt(end) == '\u00A0')) {
-            end--;
-        }
-        return input.substring(0, end + 1);
     }
 
     public boolean deleteAllGlossaries() {


### PR DESCRIPTION
Replaces non-breaking spaces and trims whitespace from glossary entries imported from Excel files. This prevents issues with the DeepL API not accepting certain characters like the protected space (U+00A0).

The `removeTrailingWhitespaces` method was removed and its functionality was replaced with a more standard `replace().trim()` chain, improving code readability and maintainability.

Also bumps the project version from 1.1.7 to 1.1.8.